### PR TITLE
Add protocol scan details into the XSLX

### DIFF
--- a/parsers/testssl/testssl.py
+++ b/parsers/testssl/testssl.py
@@ -254,7 +254,8 @@ class Testssl(Parser):
             {"header": "Host DNS"},
             {"header": "Port"},
             {"header": "Supported Protocol"},
-            {"header": "Severity"}
+            {"header": "Severity"},
+            {"header": "Information"}
         ]
 
         for input_file in self._input_files:
@@ -271,6 +272,7 @@ class Testssl(Parser):
                             int(values["port"]),
                             protocol["version"],
                             protocol["severity"],
+                            protocol["finding"]
                         ]
                     )
 
@@ -448,7 +450,8 @@ def get_host_protocols(file):
                             {
                                 "version": protocol["id"],
                                 "is_offered": "YES",
-                                "severity": protocol["severity"]
+                                "severity": protocol["severity"],
+                                "finding": protocol["finding"]
                             }
                         )
                     else:
@@ -456,7 +459,8 @@ def get_host_protocols(file):
                             {
                                 "version": protocol["id"],
                                 "is_offered": "NO",
-                                "severity": protocol["severity"]
+                                "severity": protocol["severity"],
+                                "finding": protocol["finding"]
                             }
                         )
 

--- a/parsers/testssl/testssl.py
+++ b/parsers/testssl/testssl.py
@@ -423,11 +423,11 @@ def get_host_certificates(file):
                 }
             )
     except KeyError as e:
-        #print("KeyError - skipping " + file.name)
         logging.exception("KeyError: {}".format(e))
+        logging.exception("Skipping JSON file: " + file.name)
     except ValueError as e:
-        #print("KeyError - skipping " + file.name)
         logging.exception("ValueError: {}".format(e))
+        logging.exception("Skipping JSON file: " + file.name)
 
     return results
 
@@ -470,11 +470,11 @@ def get_host_protocols(file):
                 }
             )
     except KeyError as e:
-        #print("KeyError - skipping " + file.name)
         logging.exception("KeyError: {}".format(e))
+        logging.exception("Skipping JSON file: " + file.name)
     except ValueError as e:
-        #print("ValueError - skipping " + file.name)
         logging.exception("ValueError: {}".format(e))
+        logging.exception("Skipping JSON file: " + file.name)
 
     return results
 
@@ -524,10 +524,11 @@ def get_host_vulnerabilities(file):
                 }
             )
     except KeyError as e:
-        #print("KeyError - skipping " + file.name)
         logging.exception("KeyError: {}".format(e))
+        logging.exception("Skipping JSON file: " + file.name)
+        
     except ValueError as e:
-        #print("ValueError - skipping " + file.name)
         logging.exception("ValueError: {}".format(e))
+        logging.exception("Skipping JSON file: " + file.name)
 
     return results


### PR DESCRIPTION
Hi @aress31 ,

you merged the pull request too soon ;-)

I've fixed another small issue. I noticed that the `Host vs Protocol (Details)` does not contain the actual JSON scan details. For example whether a SSL/TLS protocol is offered, not offered etc.

Will be fixed by this PR. A new column `information` will be available.

I also removed the print statements completely and exchanged them with proper logging statements.

![image](https://github.com/aress31/pentest2xlsx/assets/21357789/4b34cda4-6ddb-45db-9d70-c23bb61cfa4e)
